### PR TITLE
Broadcast unbans too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 src="https://www.gnu.org/graphics/agplv3-155x51.png">
 </a>
 
-Sentinel is a Discord bot that shares bans between servers.
+Sentinel is a Discord bot that shares bans and unbans between servers.
 
-When a user is banned in another server, Sentinel will post an alert like this to your configured alert channel:
+When a user is banned (or unbanned) in another server, Sentinel will post an alert like this to your configured alert channel:
 
 ![](docs/example.png)
 
@@ -34,6 +34,10 @@ Not right now. Currently Sentinel is in private preview, so every server it's in
 ## Can Sentinel auto-ban reported users?
 
 No. Bans cut people off from a community, and should only be used when all else has failed. Final approval on a ban should always require a human. Sentinel is a moderation tool, not a moderation replacement.
+
+## I banned someone by accident. Can I fix that?
+
+Yes, just unban them like you normally would. The bot will broadcast a notification for the unban, the same way it did for the ban. Do note that the original ban notification will still go out to other servers.
 
 # Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,33 +12,13 @@
         "@mimickal/discord-logging": "github:Mimickal/discord-logging#v1.2.1",
         "@types/js-yaml": "^4.0.5",
         "date-fns": "^2.29.3",
-        "discord-command-registry": "^2.1.0",
+        "discord-command-registry": "^2.2.1",
         "discord.js": "^14.9.0",
         "js-yaml": "^4.1.0",
         "knex": "^2.4.2",
         "node-cron": "^3.0.2",
         "sqlite3": "^5.1.6",
         "ts-node": "^10.9.1"
-      }
-    },
-    "../discord-command-registry": {
-      "version": "2.1.0",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "commander": "^10.0.1"
-      },
-      "bin": {
-        "register": "register.js"
-      },
-      "devDependencies": {
-        "chai": "^4.3.7",
-        "chai-as-promised": "^7.1.1",
-        "mocha": "^9.2.2",
-        "nyc": "^15.1.0"
-      },
-      "peerDependencies": {
-        "discord.js": "^14"
       }
     },
     "node_modules/@colors/colors": {
@@ -637,14 +617,17 @@
       "integrity": "sha512-hkhQsQyzsTJITp311WXvHZh9j4RAMfIk2hPmsWeOTN50QTpg6zqmJNfel9D/8lYNvsU01wzw9281Yke8NhYyHg=="
     },
     "node_modules/discord-command-registry": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/discord-command-registry/-/discord-command-registry-2.1.0.tgz",
-      "integrity": "sha512-2RnC9yeBD9PfJYedaPEuqjVBebzqoJuNPjssoi599DkHdokVkORhYs4FiTQtYLatnARGjzrk9ln5KthI7R1T6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/discord-command-registry/-/discord-command-registry-2.2.1.tgz",
+      "integrity": "sha512-ZI0Y2rmXFo6oPxMJ1bk14Y7yaiz61xJLCq9JNFZTrkVXiQ1NUD8/ucqcOQBhG7dKg0AI0KYXx7mSeTWySqgP7g==",
       "dependencies": {
         "commander": "^10.0.1"
       },
       "bin": {
-        "register": "register.js"
+        "register": "lib/register.js"
+      },
+      "engines": {
+        "node": ">=16.9.0"
       },
       "peerDependencies": {
         "discord.js": "^14"
@@ -2565,9 +2548,9 @@
       "integrity": "sha512-hkhQsQyzsTJITp311WXvHZh9j4RAMfIk2hPmsWeOTN50QTpg6zqmJNfel9D/8lYNvsU01wzw9281Yke8NhYyHg=="
     },
     "discord-command-registry": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/discord-command-registry/-/discord-command-registry-2.1.0.tgz",
-      "integrity": "sha512-2RnC9yeBD9PfJYedaPEuqjVBebzqoJuNPjssoi599DkHdokVkORhYs4FiTQtYLatnARGjzrk9ln5KthI7R1T6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/discord-command-registry/-/discord-command-registry-2.2.1.tgz",
+      "integrity": "sha512-ZI0Y2rmXFo6oPxMJ1bk14Y7yaiz61xJLCq9JNFZTrkVXiQ1NUD8/ucqcOQBhG7dKg0AI0KYXx7mSeTWySqgP7g==",
       "requires": {
         "commander": "^10.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentinel-discord-bot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sentinel-discord-bot",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@mimickal/discord-logging": "github:Mimickal/discord-logging#v1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-discord-bot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Discord bot for sharing bans across servers.",
   "private": true,
   "homepage": "https://github.com/Mimickal/Sentinel",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mimickal/discord-logging": "github:Mimickal/discord-logging#v1.2.1",
     "@types/js-yaml": "^4.0.5",
     "date-fns": "^2.29.3",
-    "discord-command-registry": "^2.1.0",
+    "discord-command-registry": "^2.2.1",
     "discord.js": "^14.9.0",
     "js-yaml": "^4.1.0",
     "knex": "^2.4.2",

--- a/src/ban.ts
+++ b/src/ban.ts
@@ -49,6 +49,22 @@ export async function recordUserBan({ bannedAt, guildId, reason, refBanId, user 
 	}
 }
 
+/** Removes a Ban from the database, logging any errors. */
+export async function recordUserUnban({ guildId, userId }: {
+	guildId: Snowflake;
+	userId: Snowflake;
+}): Promise<RowId> {
+	try {
+		return await database.removeBan({
+			guild_id: guildId,
+			user_id: userId,
+		});
+	} catch (err) {
+		logger.error('Failed to remove ban from database', err);
+		throw err;
+	}
+}
+
 /**
  * Bans the given User in the given Guild, and persists the ban to the database.
  * We issue these bans, so typing is a little more restrictive

--- a/src/ban.ts
+++ b/src/ban.ts
@@ -90,6 +90,26 @@ export async function banUser({ guild, reason, refBanId, user }: {
 	});
 }
 
+/**
+ * Unbans the given User in the given Guild, and persists the ban to the
+ * database.
+ *
+ * @reject {@link DiscordAPIError} if we fail to do the unban in Discord,
+ * otherwise whatever Knex throws for failed queries.
+ */
+export async function unbanUser({ guild, reason, userId }: {
+	guild: Guild;
+	reason: string;
+	userId: Snowflake;
+}): Promise<RowId> {
+	await guild.bans.remove(userId, reason)
+
+	return await recordUserUnban({
+		guildId: guild.id,
+		userId: userId,
+	});
+}
+
 /** Uses the reason on a ban to determine if the operation came from this bot. */
 export function banCameFromThisBot(ban: GuildBan): boolean {
 	// Kind of a hack, but it works.

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,12 +8,12 @@
  ******************************************************************************/
 import { formatDistance } from 'date-fns';
 import {
-	bold,
-	BaseMessageOptions,
-	Colors,
 	ActionRowBuilder,
+	BaseMessageOptions,
+	bold,
 	ButtonBuilder,
 	ButtonStyle,
+	Colors,
 	EmbedBuilder,
 	GuildBan,
 	InteractionReplyOptions,
@@ -26,10 +26,10 @@ interface BanIds {
 }
 
 /**
- * A button for banning a user.
+ * A button for performing an action on a user.
  *
  * In the interaction event for this button, information about the ban can be
- * retrieved using {@link BanButton.getBanIds}.
+ * retrieved using {@link UserActionButton.getBanIds}.
  *
  * Rationale:
  * It could be many hours (or even days) between displaying this button and an
@@ -40,35 +40,44 @@ interface BanIds {
  * I guess an alternative would be using a database or something, but I'm not
  * setting up a whole-ass database when this works fine (albeit a little weird).
  */
-export class BanButton extends ActionRowBuilder {
-	static ID_PREFIX = 'ban';
+abstract class UserActionButton extends ActionRowBuilder {
+	static ID_PREFIX: string;
 
 	static isButtonId(id: string): boolean {
-		return id.startsWith(BanButton.ID_PREFIX);
+		return id.startsWith(this.ID_PREFIX);
 	}
 
 	static getBanIds(id: string): BanIds | undefined {
-		if (BanButton.isButtonId(id)) {
+		if (this.isButtonId(id)) {
 			const ids = id.split('-');
 			return {
+				// Ignore prefix id[0]
 				userId: ids[1],
 				banId: ids[2] ? Number.parseInt(ids[2]) : undefined,
 			};
 		}
 	}
 
+	static makeBtnId({ userId, banId }: BanIds): string {
+		return `${this.ID_PREFIX}-${userId}${banId ? `-${banId}` : ''}`;
+	}
+}
+
+/** A button for banning a user. */
+export class BanButton extends UserActionButton {
+	static ID_PREFIX = 'ban';
+
 	constructor({ userId, banId }: BanIds) {
 		super();
 		this.addComponents(new ButtonBuilder()
-			.setCustomId(
-				`${BanButton.ID_PREFIX}-${userId}${banId ? `-${banId}` : ''}`
-			)
+			.setCustomId(BanButton.makeBtnId({ userId, banId }))
 			.setLabel('Ban')
 			.setStyle(ButtonStyle.Danger)
 		);
 	}
 }
 
+/** A generic disabled button. */
 export class DisabledButton extends ActionRowBuilder {
 	constructor(label: string) {
 		super();
@@ -77,6 +86,20 @@ export class DisabledButton extends ActionRowBuilder {
 			.setDisabled(true)
 			.setLabel(label)
 			.setStyle(ButtonStyle.Secondary)
+		);
+	}
+}
+
+/** A button for unbanning a user. */
+export class UnbanButton extends UserActionButton {
+	static ID_PREFIX = 'unban';
+
+	constructor({ userId, banId }: BanIds) {
+		super();
+		this.addComponents(new ButtonBuilder()
+			.setCustomId(UnbanButton.makeBtnId({ userId, banId }))
+			.setLabel('Unban')
+			.setStyle(ButtonStyle.Success)
 		);
 	}
 }
@@ -114,40 +137,69 @@ export const FileReply = ({ data, name, content }: {
 	}],
 });
 
-interface BanEmbedProps {
+interface MemberEventEmbedProps {
 	ban: GuildBan;
 	timestamp: Date;
-	inGuildSince?: Date;
-};
+}
 
-export class BanEmbed extends EmbedBuilder {
-	constructor({ ban, timestamp, inGuildSince }: BanEmbedProps) {
+/** Common config for displaying a guild member in an embed. */
+abstract class MemberEventEmbed extends EmbedBuilder {
+	constructor({ ban, timestamp }: MemberEventEmbedProps) {
 		super();
 
 		const { guild, user } = ban;
-		this.setColor(Colors.Red)
-			.setAuthor({
+		this.setAuthor({
 				name: `${user.username}#${user.discriminator}`,
 				iconURL: user.displayAvatarURL(),
 			})
-			.setDescription(bold(`${user} was banned`))
 			.addFields({
 				name: 'Account Age',
 				value: formatDistance(Date.now(), user.createdAt),
 				inline: true,
 			})
 			.addFields({ name: 'User ID', value: user.id, inline: true })
+			.setFooter({ text: guild.name, iconURL: guild.iconURL() || undefined })
+			.setTimestamp(timestamp);
+	}
+}
+
+type BanEmbedProps = MemberEventEmbedProps & { inGuildSince?: Date };
+
+/** An embed explaining why a guild member was banned. */
+export class BanEmbed extends MemberEventEmbed {
+	constructor({ ban, timestamp, inGuildSince }: BanEmbedProps) {
+		super({ ban, timestamp });
+
+		const { reason, user } = ban;
+		this.setColor(Colors.Red)
+			.setDescription(bold(`${user} was banned`))
 			.addFields({
 				name: `${inGuildSince ? '' : 'Not '} In Your Server`,
 				value: inGuildSince ? formatDistance(Date.now(), inGuildSince) : ' ',
 				inline: true,
-			})
-			.setFooter({ text: guild.name, iconURL: guild.iconURL() || undefined })
-			.setTimestamp(timestamp);
+			});
 
-		if (ban.reason) {
-			this.addFields({ name: 'Reason', value: ban.reason });
+		if (reason) {
+			this.addFields({ name: 'Reason', value: reason });
 		}
+	}
+}
+
+type UnbanEmbedProps = MemberEventEmbedProps & { bannedSince?: Date };
+
+/** An embed informing that a guild member was unbanned. */
+export class UnbanEmbed extends MemberEventEmbed {
+	constructor({ ban, timestamp, bannedSince }: UnbanEmbedProps) {
+		super({ ban, timestamp });
+
+		const { user } = ban;
+		this.setColor(Colors.Green)
+			.setDescription(bold(`${user} was unbanned`))
+			.addFields({
+				name: `${bannedSince ? '' : 'Not '} Banned In Your Server`,
+				value: bannedSince ? formatDistance(Date.now(), bannedSince) : ' ',
+				inline: true,
+			});
 	}
 }
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -18,18 +18,21 @@ import {
 	GuildBan,
 	InteractionReplyOptions,
 	MessageEditOptions,
+	Snowflake,
 } from 'discord.js';
 
-interface BanIds {
-	userId: string;
+export interface BanIds {
+	userId: Snowflake;
 	banId?: number;
 }
+
+type IdString = `${string}-${string}` | `${string}-${string}-${string}`;
 
 /**
  * A button for performing an action on a user.
  *
  * In the interaction event for this button, information about the ban can be
- * retrieved using {@link UserActionButton.getBanIds}.
+ * retrieved using {@link Button.getBanIds}.
  *
  * Rationale:
  * It could be many hours (or even days) between displaying this button and an
@@ -40,22 +43,40 @@ interface BanIds {
  * I guess an alternative would be using a database or something, but I'm not
  * setting up a whole-ass database when this works fine (albeit a little weird).
  */
-abstract class UserActionButton extends ActionRowBuilder {
+export abstract class Button extends ActionRowBuilder {
 	static ID_PREFIX: string;
 
-	static isButtonId(id: string): boolean {
-		return id.startsWith(this.ID_PREFIX);
+	/** Determines if the given string is any valid button ID format. */
+	private static hasIds(id: string): id is IdString {
+		const ids = id.split('-');
+		return (
+			ids[1].length >= 18 && // Snowflake length
+			2 <= ids.length     &&
+			3 >= ids.length
+		);
 	}
 
-	static getBanIds(id: string): BanIds | undefined {
-		if (this.isButtonId(id)) {
-			const ids = id.split('-');
-			return {
-				// Ignore prefix id[0]
-				userId: ids[1],
-				banId: ids[2] ? Number.parseInt(ids[2]) : undefined,
-			};
-		}
+	/**
+	 * Determines if the given string is an ID for this button.
+	 * Subclasses inherit this and override {@link ID_PREFIX}.
+	 */
+	static isButtonId(id: string): id is IdString {
+		const ids = id.split('-');
+		return ids[0] === this.ID_PREFIX && this.hasIds(id);
+	}
+
+	/** Extracts ban IDs from the given string. */
+	static getBanIds(id: IdString): BanIds;
+	static getBanIds(id: string): BanIds | undefined;
+	static getBanIds(id: string | IdString): BanIds | undefined {
+		if (!this.hasIds(id)) return;
+
+		const ids = id.split('-');
+		return {
+			// Ignore prefix id[0]
+			userId: ids[1],
+			banId: ids[2] ? Number.parseInt(ids[2]) : undefined,
+		};
 	}
 
 	static makeBtnId({ userId, banId }: BanIds): string {
@@ -64,7 +85,7 @@ abstract class UserActionButton extends ActionRowBuilder {
 }
 
 /** A button for banning a user. */
-export class BanButton extends UserActionButton {
+export class BanButton extends Button {
 	static ID_PREFIX = 'ban';
 
 	constructor({ userId, banId }: BanIds) {
@@ -91,7 +112,7 @@ export class DisabledButton extends ActionRowBuilder {
 }
 
 /** A button for unbanning a user. */
-export class UnbanButton extends UserActionButton {
+export class UnbanButton extends Button {
 	static ID_PREFIX = 'unban';
 
 	constructor({ userId, banId }: BanIds) {

--- a/src/components.ts
+++ b/src/components.ts
@@ -36,6 +36,9 @@ interface BanIds {
  * admin clicking it, if they ever click it at all. Because of this, we need to
  * embed information about the ban in the button itself. The only way to do this
  * is through its ID.
+ *
+ * I guess an alternative would be using a database or something, but I'm not
+ * setting up a whole-ass database when this works fine (albeit a little weird).
  */
 export class BanButton extends ActionRowBuilder {
 	static ID_PREFIX = 'ban';
@@ -62,6 +65,18 @@ export class BanButton extends ActionRowBuilder {
 			)
 			.setLabel('Ban')
 			.setStyle(ButtonStyle.Danger)
+		);
+	}
+}
+
+export class DisabledButton extends ActionRowBuilder {
+	constructor(label: string) {
+		super();
+		this.addComponents(new ButtonBuilder()
+			.setCustomId('Ignored')
+			.setDisabled(true)
+			.setLabel(label)
+			.setStyle(ButtonStyle.Secondary)
 		);
 	}
 }

--- a/src/database/operations.ts
+++ b/src/database/operations.ts
@@ -82,10 +82,18 @@ export async function getGuildBans(guildId: Snowflake): Promise<BanRow[]> {
 		.where('guild_id', '=', guildId);
 }
 
-export async function removeBan(ban: FetchBanRow): Promise<void> {
-	await knex<FetchBanRow>(Tables.BANS)
+export async function removeBan(ban: FetchBanRow): Promise<RowId> {
+	// Delete returning isn't playing nice so we do this instead.
+	// Yes, this introduces a race condition, but we'll probably never hit it.
+	const returned = await knex<BanRow>(Tables.BANS)
+		.select()
+		.where(ban);
+
+	await knex<BanRow>(Tables.BANS)
 		.delete()
 		.where(ban);
+
+	return returned[0]?.id;
 }
 
 export async function getGuildConfig(id: Snowflake): Promise<ConfigRow[]> {

--- a/src/events.ts
+++ b/src/events.ts
@@ -22,6 +22,7 @@ import commands from './commands';
 import {
 	BanEmbed,
 	BanButton,
+	DisabledButton,
 	ErrorMsg,
 	GoodMsg,
 	InfoMsg,
@@ -190,7 +191,7 @@ async function sendBanAlert({ ban, bannedAt, banId, guildRow }: {
 			timestamp: bannedAt,
 			inGuildSince: inGuildSince,
 		})],
-		// @ts-ignore TODO ask djs support why this type isn't playing nice.
+		// @ts-expect-error TODO ask djs support why this type isn't playing nice.
 		components: [new BanButton({ userId: ban.user.id, banId })],
 	});
 }
@@ -252,6 +253,18 @@ async function handleButtonInteraction(interaction: ButtonInteraction): Promise<
 			));
 		}
 		return;
+	}
+
+	try {
+		await interaction.message.edit({
+			// @ts-expect-error TODO ask djs devs what's up
+			components: [new DisabledButton('Banned')],
+		});
+	} catch (err) {
+		// If we fail to disable this button, the worst thing that happens is
+		// someone might click it again, which we account for. The ban already
+		// happened, so just log this failure and move on.
+		logger.warn(`Failed to disable ban button on ${detail(interaction.message)}`);
 	}
 
 	await interaction.reply(GoodMsg(`Banned user ${userMention(userId)}`));

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,10 +50,14 @@ client.on(Discord.Events.InteractionCreate, events.onInteraction);
 // Every day at midnight
 cron.schedule('0 0 * * *', () => checkForDeletedUsers(client))
 
-logger.info(`Bot is starting with config: ${JSON.stringify({
-	...config.Env,
-	token: '<REDACTED>',
-})}`);
+logger.info(
+	`Bot is starting version ${
+		config.Package.version
+	} with config: ${JSON.stringify({
+		...config.Env,
+		token: '<REDACTED>',
+	})}`
+);
 
 client.login(config.Env.token).catch(err => {
 	logger.error('Failed to log in!', err);

--- a/src/util.ts
+++ b/src/util.ts
@@ -93,3 +93,15 @@ export async function* fetchAll<
 		cursor = page.lastKey();
 	} while (page.size === limit);
 }
+
+/**
+ * Resolves a Promise and ignores any error it might throw.
+ * This is useful because Discord.js throws an error when you try to do things
+ * like fetching a ban for a user that isn't banned. For our purposes, it's
+ * better to have `undefined` instead.
+ */
+export async function ignoreError<T>(func: () => Promise<T>): Promise<T | undefined> {
+	try {
+		return await func();
+	} catch {}
+}


### PR DESCRIPTION
This change makes the bot broadcast to other servers when a user is unbanned. This follows all the same rules as the existing ban broadcast functionality.

This also fixes an (unlikely) issue where the ban button would incorrectly report that a user had already been banned when they weren't if the bot's internal ban storage falls out of sync with Discord. In practice, this would only really happen if a ban went out while the bot was offline. 